### PR TITLE
zephyr-litex: update litex_term location

### DIFF
--- a/source/zephyr-litex.rst
+++ b/source/zephyr-litex.rst
@@ -92,7 +92,7 @@ Loading Zephyr
 
       .. code-block:: text
 
-         wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex/utils/litex_term.py
+         wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex/tools/litex_term.py
          chmod u+x litex_term.py
 
          ./litex_term.py --serial-boot --kernel zephyr.bin /dev/ttyUSB1


### PR DESCRIPTION
Thanks for integrating LiteX in the risc-v-getting-started-guide!

The tools have been reorganized a bit, here is a patch to keep
things up to date in the guide.